### PR TITLE
Removed accidental complexity from RandomHbbft contract

### DIFF
--- a/contracts/InitializerHbbft.sol
+++ b/contracts/InitializerHbbft.sol
@@ -73,7 +73,6 @@ contract InitializerHbbft {
             _acks
         );
         IBlockRewardHbbft(_contracts[1]).initialize(_contracts[0], _blockReward);
-        IRandomHbbft(_contracts[2]).initialize(_contracts[0]);
         address[] memory permittedAddresses = new address[](1);
         permittedAddresses[0] = _owner;
         ITxPermission(_contracts[4]).initialize(permittedAddresses, _contracts[5], _contracts[0]);

--- a/contracts/RandomHbbft.sol
+++ b/contracts/RandomHbbft.sol
@@ -1,7 +1,6 @@
 pragma solidity ^0.5.16;
 
 import "./interfaces/IRandomHbbft.sol";
-import "./interfaces/IValidatorSetHbbft.sol";
 import "./upgradeability/UpgradeabilityAdmin.sol";
 
 /// @dev Stores and uppdates a random seed that is used to form a new validator set by the
@@ -18,23 +17,7 @@ contract RandomHbbft is UpgradeabilityAdmin, IRandomHbbft {
     /// (depending on implementation).
     uint256 public currentSeed;
 
-
-    /// @dev The address of the `ValidatorSetHbbft` contract.
-    IValidatorSetHbbft public validatorSetContract;
-
     // ============================================== Modifiers =======================================================
-
-    /// @dev Ensures the caller is the BlockRewardHbbft contract address.
-    modifier onlyBlockReward() {
-        require(msg.sender == validatorSetContract.blockRewardContract(), "Must be executed by blockRewardContract.");
-        _;
-    }
-
-    /// @dev Ensures the `initialize` function was called before.
-    modifier onlyInitialized {
-        require(isInitialized(), "RandomHbbft must be initialized!");
-        _;
-    }
 
     /// @dev Ensures the caller is the SYSTEM_ADDRESS. See https://wiki.parity.io/Validator-Set.html
     modifier onlySystem() {
@@ -43,51 +26,9 @@ contract RandomHbbft is UpgradeabilityAdmin, IRandomHbbft {
     }
     // =============================================== Setters ========================================================
 
-
     function setCurrentSeed(uint256 _currentSeed)
     external
-    onlyInitialized
     onlySystem {
         currentSeed = _currentSeed;
-    }
-
-    /// @dev Initializes the contract at network startup.
-    /// Can only be called by the constructor of the `InitializerHbbft` contract or owner.
-    /// @param _validatorSet The address of the `ValidatorSet` contract.
-    function initialize(
-        address _validatorSet
-    ) external {
-        _initialize(_validatorSet);
-    }
-
-    // =============================================== Getters ========================================================
-
-    /// @dev Returns a boolean flag indicating if the `initialize` function has been called.
-    function isInitialized()
-    public
-    view
-    returns(bool) {
-        return validatorSetContract != IValidatorSetHbbft(0);
-    }
-
-
-    // ============================================== Internal ========================================================
-
-    /// @dev Initializes the network parameters. Used by the `initialize` function.
-    /// @param _validatorSet The address of the `ValidatorSetHbbft` contract.
-    function _initialize(address _validatorSet)
-    internal {
-        require(msg.sender == _admin() || block.number == 0, "Must be executed by admin");
-        require(!isInitialized(), "initialization can only be done once");
-        require(_validatorSet != address(0), "ValidatorSet must not be 0");
-        validatorSetContract = IValidatorSetHbbft(_validatorSet);
-    }
-
-    /// @dev Returns the current `coinbase` address. Needed mostly for unit tests.
-    function _getCoinbase()
-    internal
-    view
-    returns(address) {
-        return block.coinbase;
     }
 }

--- a/contracts/interfaces/IRandomHbbft.sol
+++ b/contracts/interfaces/IRandomHbbft.sol
@@ -2,6 +2,5 @@ pragma solidity ^0.5.16;
 
 
 interface IRandomHbbft {
-    function initialize(address) external;
     function currentSeed() external view returns(uint256);
 }

--- a/test/BlockRewardHbbft.js
+++ b/test/BlockRewardHbbft.js
@@ -116,12 +116,6 @@ contract('BlockRewardHbbft', async accounts => {
         validatorSetHbbft.address,
         MAX_BLOCK_REWARD
       ).should.be.fulfilled;
-
-      // Initialize RandomHbbft
-      await randomHbbft.initialize(
-        validatorSetHbbft.address
-      ).should.be.fulfilled;
-
     });
 
 

--- a/test/StakingHbbft.js
+++ b/test/StakingHbbft.js
@@ -329,11 +329,6 @@ contract('StakingHbbft', async accounts => {
         maxEpochReward
       ).should.be.fulfilled;
 
-      // Initialize RandomHbbft
-      await randomHbbft.initialize(
-        validatorSetHbbft.address
-      ).should.be.fulfilled;
-
       // Initialize StakingHbbft
       await stakingHbbft.initialize(
         validatorSetHbbft.address, // _validatorSetContract

--- a/test/ValidatorSetHbbft.js
+++ b/test/ValidatorSetHbbft.js
@@ -402,7 +402,6 @@ contract('ValidatorSetHbbft', async accounts => {
 
       // Generate a random seed
       (await randomHbbft.currentSeed.call()).should.be.bignumber.equal(new BN(0));
-      await randomHbbft.initialize(validatorSetHbbft.address).should.be.fulfilled;
 
       const seed = random(1000000, 2000000);
       await randomHbbft.setSystemAddress(owner).should.be.fulfilled;

--- a/test/mockContracts/RandomHbbftMock.sol
+++ b/test/mockContracts/RandomHbbftMock.sol
@@ -27,12 +27,7 @@ contract RandomHbbftMock is RandomHbbft {
 
     // =============================================== Private ========================================================
 
-    function _getCoinbase() internal view returns(address) {
-        return _coinbase != address(0) ? _coinbase : block.coinbase;
-    }
-
     function _getSystemAddress() internal view returns(address) {
         return _systemAddress;
     }
-
 }


### PR DESCRIPTION
onlyBlockReward() is not required with hbbft, which means validatorSetContract is not required, which means initialize() is not required, which means isInitialized() is not required, which means onlyInitialized() is not required.
_getCoinbase() does not seem to be used anywhere, eliminated as well.