### PR TITLE
added stakingEpochStartBlock for allowing historic lookups of PARTS and ACKS for the current epoch.

### DIFF
--- a/contracts/TxPermissionHbbft.sol
+++ b/contracts/TxPermissionHbbft.sol
@@ -242,11 +242,11 @@ contract TxPermissionHbbft is UpgradeableOwned, ITxPermission {
     }
 
     /// @dev Returns the current block gas limit which depends on the stage of the current
-    /// staking epoch: the block gas limit is temporarily reduced for the latest block of the epoch.
+    // /// staking epoch: the block gas limit is temporarily reduced for the latest block of the epoch.
     // function blockGasLimit() public view returns(uint256) {
     //     address stakingContract = validatorSetContract.stakingContract();
-    //     uint256 stakingEpochEndBlock = IStakingHbbft(stakingContract).stakingFixedEpochEndBlock();
-    //     if (block.number == stakingEpochEndBlock - 1 || block.number == stakingEpochEndBlock) {
+    //     uint256 stakingEpochEndTime = IStakingHbbft(stakingContract).stakingFixedEpochEndTime();
+    //     if (block.timestamp == stakingEpochEndBlock - 1 || block.number == stakingEpochEndBlock) {
     //         return BLOCK_GAS_LIMIT_REDUCED;
     //     }
     //     return BLOCK_GAS_LIMIT;

--- a/contracts/base/StakingHbbftBase.sol
+++ b/contracts/base/StakingHbbftBase.sol
@@ -128,9 +128,16 @@ contract StakingHbbftBase is UpgradeableOwned, IStakingHbbft {
     /// @dev Length of the timeframe in seconds for the transition to the new validator set.
     uint256 public stakingTransitionTimeframeLength;
 
-    /// @dev The timestampt of the last block of the the previous epoch. 
+    /// @dev The timestamp of the last block of the the previous epoch. 
     /// The timestamp of the current epoch must be '>=' than this.
     uint256 public stakingEpochStartTime;
+
+    /// @dev the blocknumber of the first block in this epoch.
+    /// this is mainly used for a historic lookup in the key gen history to read out the 
+    /// ACKS and PARTS so a client is able to verify an epoch, even in the case that 
+    /// the transition to the next epoch has already started, 
+    /// and the information of the old keys is not available anymore. 
+    uint256 public stakingEpochStartBlock;
 
     /// @dev Returns the total amount of staking coins currently staked into the specified pool.
     /// Doesn't include the amount ordered for withdrawal.
@@ -375,6 +382,7 @@ contract StakingHbbftBase is UpgradeableOwned, IStakingHbbft {
     external
     onlyValidatorSetContract {
         stakingEpochStartTime = _timestamp;
+        stakingEpochStartBlock = block.number + 1;
     }
 
     /// @dev Moves staking coins from one pool to another. A staker calls this function when they want


### PR DESCRIPTION
added stakingEpochStartBlock. 
the blocknumber of the first block in this epoch.
this is mainly used for a historic lookup in the key gen history to read out the
ACKS and PARTS so a client is able to verify an epoch, even in the case that
the transition to the next epoch has already started,
and the information of the old keys is not available anymore.