### PR TITLE
corrected stakingEpochStartBlock to the value when the transition to …

### DIFF
--- a/contracts/base/StakingHbbftBase.sol
+++ b/contracts/base/StakingHbbftBase.sol
@@ -382,7 +382,7 @@ contract StakingHbbftBase is UpgradeableOwned, IStakingHbbft {
     external
     onlyValidatorSetContract {
         stakingEpochStartTime = _timestamp;
-        stakingEpochStartBlock = block.number + 1;
+        stakingEpochStartBlock = block.number;
     }
 
     /// @dev Moves staking coins from one pool to another. A staker calls this function when they want


### PR DESCRIPTION
…the new epoch really happens. (instead of pointing to the first block "IN" the new epoch)